### PR TITLE
Installation of emulators/i386-wine fails to execute nvidia.sh script on latest nvidia-driver version

### DIFF
--- a/emulators/i386-wine/files/nvidia.sh
+++ b/emulators/i386-wine/files/nvidia.sh
@@ -168,21 +168,21 @@ echo "=> Detected nvidia-driver: ${NV}"
 NVIDIA=${NV}
 NV=`echo ${NV} | cut -f 1 -d _ | cut -f 1 -d ,`
 
-if [ ! -f NVIDIA-FreeBSD-x86-${NV}.tar.gz ] || !(tar -tf NVIDIA-FreeBSD-x86-${NV}.tar.gz > /dev/null 2>&1)
+if [ ! -f NVIDIA-FreeBSD-x86_64-${NV}.tar.gz ] || !(tar -tf NVIDIA-FreeBSD-x86_64-${NV}.tar.gz > /dev/null 2>&1)
 then
   [ -n "$NO_FETCH" ] \
     && terminate 8 "NVIDIA-FreeBSD-x86-${NV}.tar.gz unavailable"
   echo "=> Downloading NVIDIA-FreeBSD-x86-${NV}.tar.gz from https://download.nvidia.com..."
-  rm -f NVIDIA-FreeBSD-x86-${NV}.tar.gz
-  fetch -aRr https://download.nvidia.com/XFree86/FreeBSD-x86/${NV}/NVIDIA-FreeBSD-x86-${NV}.tar.gz \
-    || terminate 2 "Failed to download NVIDIA-FreeBSD-x86-${NV}.tar.gz"
-  echo "=> Downloaded NVIDIA-FreeBSD-x86-${NV}.tar.gz"
+  rm -f NVIDIA-FreeBSD-x86_64-${NV}.tar.gz
+  fetch -aRr https://download.nvidia.com/XFree86/FreeBSD-x86_64/${NV}/NVIDIA-FreeBSD-x86_64-${NV}.tar.gz \
+    || terminate 2 "Failed to download NVIDIA-FreeBSD-x86_64-${NV}.tar.gz"
+  echo "=> Downloaded NVIDIA-FreeBSD-x86_64-${NV}.tar.gz"
   echo "Please check the following information against /usr/ports/x11/nvidia-driver/distinfo"
-  sha256 NVIDIA-FreeBSD-x86-${NV}.tar.gz
-  echo "SIZE (NVIDIA-FreeBSD-x86-${NV}.tar.gz) = `stat -f "%z" NVIDIA-FreeBSD-x86-${NV}.tar.gz`"
+  sha256 NVIDIA-FreeBSD-x86_64-${NV}.tar.gz
+  echo "SIZE (NVIDIA-FreeBSD-x86_64-${NV}.tar.gz) = `stat -f "%z" NVIDIA-FreeBSD-x86_64-${NV}.tar.gz`"
 fi
 
-echo "=> Extracting NVIDIA-FreeBSD-x86-${NV}.tar.gz to $PREFIX/lib32..."
+echo "=> Extracting NVIDIA-FreeBSD-x86_64-${NV}.tar.gz to $PREFIX/lib32..."
 EXTRACT_LIST="libGL.so.1"
 case $NV in
   195*|173*|96*|71*)
@@ -196,20 +196,24 @@ esac
 EXTRACT_ARGS="--no-same-owner --no-same-permissions --strip-components 2 -C $PREFIX/lib32"
 for i in $EXTRACT_LIST
 do
-  EXTRACT_ARGS="$EXTRACT_ARGS --include NVIDIA-FreeBSD-x86-${NV}/obj/$i"
+  if [ $i == "libGL.so.1" ] ; then	
+     EXTRACT_ARGS="$EXTRACT_ARGS --include NVIDIA-FreeBSD-x86_64-${NV}/obj/libglvnd/32/$i"
+  else   
+     EXTRACT_ARGS="$EXTRACT_ARGS --include NVIDIA-FreeBSD-x86_64-${NV}/obj/32/$i"
+  fi   
 done
 umask 0333
-tar $EXTRACT_ARGS -xvf NVIDIA-FreeBSD-x86-${NV}.tar.gz \
+tar $EXTRACT_ARGS -xvf NVIDIA-FreeBSD-x86_64-${NV}.tar.gz \
   || terminate 3 "Failed to extract NVIDIA-FreeBSD-x86-${NV}.tar.gz"
 mkdir -m 0755 -p ${PREFIX}/lib32/.nvidia \
   || terminate 9 "Failed to create .nvidia shadow directory"
 mv ${PREFIX}/lib32/libGL.so.1 ${PREFIX}/lib32/.nvidia/ \
   || terminate 10 "Failed to move libGL.so.1 to .nvidia/ shadow directory"
 ln -s .nvidia/libGL.so.1 ${PREFIX}/lib32/libGL.so.1 \
-  || terminate 11 "Failed to link to .nvidia/libGL.so.1 in the shadow directory"
+  || terminate 11 "Failed to link to .nvidia/libGL.so.1 in the shadow directory" 
 
 echo "=> Cleaning up..."
-[ -n "$NO_REMOVE_NVIDIA" ] || rm -vf NVIDIA-FreeBSD-x86-${NV}.tar.gz \
+[ -n "$NO_REMOVE_NVIDIA" ] || rm -vf NVIDIA-FreeBSD-x86_64-${NV}.tar.gz \
   || terminate 6 "Failed to remove files"
 
 echo "===> i386-wine-${WINE} successfully patched for nvidia-driver-${NVIDIA}"

--- a/emulators/i386-wine/files/nvidia.sh
+++ b/emulators/i386-wine/files/nvidia.sh
@@ -167,22 +167,34 @@ echo "=> Detected nvidia-driver: ${NV}"
 
 NVIDIA=${NV}
 NV=`echo ${NV} | cut -f 1 -d _ | cut -f 1 -d ,`
+NVmajor=`echo $NV | sed -E 's/([0-9]+)\.[0-9]+/\1/'`
 
-if [ ! -f NVIDIA-FreeBSD-x86_64-${NV}.tar.gz ] || !(tar -tf NVIDIA-FreeBSD-x86_64-${NV}.tar.gz > /dev/null 2>&1)
-then
-  [ -n "$NO_FETCH" ] \
-    && terminate 8 "NVIDIA-FreeBSD-x86-${NV}.tar.gz unavailable"
-  echo "=> Downloading NVIDIA-FreeBSD-x86-${NV}.tar.gz from https://download.nvidia.com..."
-  rm -f NVIDIA-FreeBSD-x86_64-${NV}.tar.gz
-  fetch -aRr https://download.nvidia.com/XFree86/FreeBSD-x86_64/${NV}/NVIDIA-FreeBSD-x86_64-${NV}.tar.gz \
-    || terminate 2 "Failed to download NVIDIA-FreeBSD-x86_64-${NV}.tar.gz"
-  echo "=> Downloaded NVIDIA-FreeBSD-x86_64-${NV}.tar.gz"
-  echo "Please check the following information against /usr/ports/x11/nvidia-driver/distinfo"
-  sha256 NVIDIA-FreeBSD-x86_64-${NV}.tar.gz
-  echo "SIZE (NVIDIA-FreeBSD-x86_64-${NV}.tar.gz) = `stat -f "%z" NVIDIA-FreeBSD-x86_64-${NV}.tar.gz`"
+# nvidia-driver v390.132 was the last one shipping 
+# 32-bit library package, after that only x86_64 is shipped containing 
+# both 32-bit and 64-bit GL libraries
+if [ ${NVmajor} -gt 390 ] ; then
+    downloadFilename=NVIDIA-FreeBSD-x86_64-${NV}.tar.gz  
+    downloadDirectory=FreeBSD-x86_64
+else
+    downloadFilename=NVIDIA-FreeBSD-x86-${NV}.tar.gz
+    downloadDirectory=FreeBSD-x86
 fi
 
-echo "=> Extracting NVIDIA-FreeBSD-x86_64-${NV}.tar.gz to $PREFIX/lib32..."
+if [ ! -f ${downloadFilename} ] || !(tar -tf ${downloadFilename} > /dev/null 2>&1)
+then
+  [ -n "$NO_FETCH" ] \
+    && terminate 8 "${downloadFilename} unavailable"
+  echo "=> Downloading ${downloadFilename} from https://download.nvidia.com..."
+  rm -f ${downloadFilename}
+  fetch -aRr https://download.nvidia.com/XFree86/${downloadDirectory}/${NV}/${downloadFilename} \
+    || terminate 2 "Failed to download ${downloadFilename}"
+  echo "=> Downloaded ${downloadFilename}"
+  echo "Please check the following information against /usr/ports/x11/nvidia-driver/distinfo"
+  sha256 ${downloadFilename}
+  echo "SIZE (${downloadFilename}) = `stat -f "%z" ${downloadFilename}`"
+fi
+
+echo "=> Extracting ${downloadFilename} to $PREFIX/lib32..."
 EXTRACT_LIST="libGL.so.1"
 case $NV in
   195*|173*|96*|71*)
@@ -196,15 +208,19 @@ esac
 EXTRACT_ARGS="--no-same-owner --no-same-permissions --strip-components 2 -C $PREFIX/lib32"
 for i in $EXTRACT_LIST
 do
-  if [ $i == "libGL.so.1" ] ; then	
-     EXTRACT_ARGS="$EXTRACT_ARGS --include NVIDIA-FreeBSD-x86_64-${NV}/obj/libglvnd/32/$i"
-  else   
-     EXTRACT_ARGS="$EXTRACT_ARGS --include NVIDIA-FreeBSD-x86_64-${NV}/obj/32/$i"
-  fi   
+  if [ ${NVmajor} -ge 390 ] ; then
+      if [ $i == "libGL.so.1" ] ; then	
+          EXTRACT_ARGS="$EXTRACT_ARGS --include NVIDIA-FreeBSD-x86_64-${NV}/obj/libglvnd/32/$i"
+      else   
+          EXTRACT_ARGS="$EXTRACT_ARGS --include NVIDIA-FreeBSD-x86_64-${NV}/obj/32/$i"
+      fi
+  else
+          EXTRACT_ARGS="$EXTRACT_ARGS --include NVIDIA-FreeBSD-x86-${NV}/obj/$i"
+  fi 
 done
 umask 0333
-tar $EXTRACT_ARGS -xvf NVIDIA-FreeBSD-x86_64-${NV}.tar.gz \
-  || terminate 3 "Failed to extract NVIDIA-FreeBSD-x86-${NV}.tar.gz"
+tar $EXTRACT_ARGS -xvf ${downloadFilename} \
+  || terminate 3 "Failed to extract ${downloadFilename}"
 mkdir -m 0755 -p ${PREFIX}/lib32/.nvidia \
   || terminate 9 "Failed to create .nvidia shadow directory"
 mv ${PREFIX}/lib32/libGL.so.1 ${PREFIX}/lib32/.nvidia/ \
@@ -213,7 +229,7 @@ ln -s .nvidia/libGL.so.1 ${PREFIX}/lib32/libGL.so.1 \
   || terminate 11 "Failed to link to .nvidia/libGL.so.1 in the shadow directory" 
 
 echo "=> Cleaning up..."
-[ -n "$NO_REMOVE_NVIDIA" ] || rm -vf NVIDIA-FreeBSD-x86_64-${NV}.tar.gz \
+[ -n "$NO_REMOVE_NVIDIA" ] || rm -vf ${downloadFilename} \
   || terminate 6 "Failed to remove files"
 
 echo "===> i386-wine-${WINE} successfully patched for nvidia-driver-${NVIDIA}"


### PR DESCRIPTION
Hello all, 
It appears that on the latest nvidia-driver version such as *v440.53* *emultators/i386-wine* fails on the installation step of running *files/nvidia.sh* script. The reason seems to be that NVidia does not package 32-bit libraries separately but rather in the same FreeBSD-x86_64  package since *v396.13*

I tested the fix on my system  and the nvidia.sh script completed successfully.

Please see NVidia explanation about this issue on their forums: https://devtalk.nvidia.com/default/topic/1065886/freebsd-solaris/request-include-32-bit-libraries-with-64-bit-drivers/

I also raised this on FreeBSD bugtracker hoping to get it patched from upstream: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=244547


