### PR TITLE
ghostbsd: Reduce the 'read size' of the Prefetch to improve SMB support

### DIFF
--- a/multimedia/vlc/files/patch-modules_stream_filter_prefetch.c
+++ b/multimedia/vlc/files/patch-modules_stream_filter_prefetch.c
@@ -1,0 +1,11 @@
+--- modules/stream_filter/prefetch.c
++++ modules/stream_filter/prefetch.c
+@@ -534,7 +534,7 @@ vlc_module_begin()
+     add_integer("prefetch-buffer-size", 1 << 14, N_("Buffer size"),
+                 N_("Prefetch buffer size (KiB)"), false)
+         change_integer_range(4, 1 << 20)
+-    add_integer("prefetch-read-size", 1 << 24, N_("Read size"),
++    add_integer("prefetch-read-size", 1 << 23, N_("Read size"),
+                 N_("Prefetch background read size (bytes)"), true)
+         change_integer_range(1, 1 << 29)
+     add_integer("prefetch-seek-threshold", 1 << 14, N_("Seek threshold"),


### PR DESCRIPTION
Reduce the size of "read size" in the "Prefetch" allows to suppress read errors
when the SMB module is used.
The backport of commit "prefetch: remove read size, always request maximum" [1]
did not fix the problem.

[1] https://github.com/videolan/vlc/commit/6f58cd15a29ec77f5117e709a5c5a7126b9148c8