### PR TITLE
fix the output of uname in sysutils/mate-system-monitor

### DIFF
--- a/sysutils/mate-system-monitor/files/patch-sysinfo.cpp
+++ b/sysutils/mate-system-monitor/files/patch-sysinfo.cpp
@@ -1,0 +1,11 @@
+--- src/sysinfo.cpp
++++ src/sysinfo.cpp
+@@ -413,7 +413,7 @@ namespace {
+ #elif defined(__sun) && defined(__SVR4)
+             this->kernel = string(uname().sysname) + ' ' + uname().release + ' ' + uname().version + ' ' + uname().machine;
+ #else
+-            this->kernel = string(uname().version) + ' ' + uname().machine;
++            this->kernel = string(uname().sysname) + ' ' + uname().release + ' ' + uname().machine;
+ #endif
+         }
+ 


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/4661917/192138887-552eea49-88e2-43ff-9570-fc86025e413b.png)

After:
![after](https://user-images.githubusercontent.com/4661917/192138888-47370464-b122-4a7b-b77d-7c00ffe975dd.png)
