### PR TITLE
removed os related code in actual-package-depends.sh

### DIFF
--- a/Mk/Scripts/actual-package-depends.sh
+++ b/Mk/Scripts/actual-package-depends.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# MAINTAINER: portmgr@FeeeBSD.org
+# MAINTAINER: portmgr@FreeBSD.org
 
 [ -n "${DEBUG_MK_SCRIPTS}" -o -n "${DEBUG_MK_SCRIPTS_ACTUAL_PACKAGE_DEPENDS}" ] && set -x
 
@@ -68,66 +68,6 @@ find_dep() {
 	fi
 }
 
-inject_base_dep() {
-	ORIGIN="${1}"
-	NAME=$(make -C ${PORTSDIR}/${ORIGIN} -V PKGBASE)
-	VERSION=$(make -C ${PORTSDIR}/${ORIGIN} -V PKGVERSION)
-	echo "\"${NAME}\": {origin: \"${ORIGIN}\", version: \"$VERSION\"}"
-}
-
 for lookup; do
-	# Ugly, but currently we cannot install BASE packages into read-only poudriere base
-	# This allows us to still inject depends on os/* packages
-	case ${lookup} in
-		/COPYRIGHT)
-			inject_base_dep "os/userland-base"
-			continue
-			;;
-		/bin/sh)
-			inject_base_dep "os/userland-bin"
-			continue
-			;;
-		/boot/defaults/loader.conf)
-			inject_base_dep "os/userland-boot"
-			continue
-			;;
-		/libexec/ld-elf.so.1)
-			inject_base_dep "os/userland-base-bootstrap"
-			continue
-			;;
-		/etc/rc)
-			inject_base_dep "os/userland-conf"
-			continue
-			;;
-		/usr/lib/debug/bin/sh.debug)
-			inject_base_dep "os/userland-debug"
-			continue
-			;;
-		/usr/share/man/man1/sh.1.gz)
-			inject_base_dep "os/userland-docs"
-			continue
-			;;
-		/usr/lib/libelf.so)
-			inject_base_dep "os/userland-lib"
-			continue
-			;;
-		/usr/lib32/libc.so)
-			inject_base_dep "os/userland-lib32"
-			continue
-			;;
-		/rescue/sh)
-			inject_base_dep "os/userland-rescue"
-			continue
-			;;
-		/sbin/init)
-			inject_base_dep "os/userland-sbin"
-			continue
-			;;
-		/usr/tests/README)
-			inject_base_dep "os/userland-tests"
-			continue
-			;;
-		*) ;;
-	esac
 	${PKG_BIN} query "\"%n\": {origin: \"%o\", version: \"%v\"}" "$(find_dep ${lookup})" || :
 done


### PR DESCRIPTION
This PR fixes the issue with rpm4

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove the code responsible for injecting dependencies on OS packages in the actual-package-depends.sh script, simplifying the script by eliminating special handling for base system components.

Enhancements:
- Remove OS-related dependency injection code from the actual-package-depends.sh script.

<!-- Generated by sourcery-ai[bot]: end summary -->