### PR TITLE
net/rsync: update to 3.4.0

### DIFF
--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	rsync
-DISTVERSION=	3.3.0
+DISTVERSION=	3.4.0
 CATEGORIES=	net
 MASTER_SITES=	https://www.mirrorservice.org/sites/rsync.samba.org/src/ \
 		http://rsync.mirror.garr.it/src/ \
@@ -100,10 +100,10 @@ post-install:
 	@${MKDIR} ${STAGEDIR}${ETCDIR}
 	${INSTALL_DATA} ${FILESDIR}/rsyncd.conf.sample ${STAGEDIR}${ETCDIR}/
 	${INSTALL_SCRIPT} ${WRKSRC}/support/rrsync ${STAGEDIR}${PREFIX}/sbin
-	${INSTALL_MAN} ${WRKSRC}/rrsync.1 ${STAGEDIR}${PREFIX}/share/man/man1/
 
 post-install-DOCS-on:
 	@${MKDIR} ${STAGEDIR}${DOCSDIR}
 	${INSTALL_DATA} ${PORTDOCS:S,^,${WRKSRC}/,} ${STAGEDIR}${DOCSDIR}
+	${INSTALL_DATA} ${WRKSRC}/support/rrsync.1.md ${STAGEDIR}${DOCSDIR}
 
 .include <bsd.port.post.mk>

--- a/net/rsync/distinfo
+++ b/net/rsync/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1712443181
-SHA256 (rsync-3.3.0.tar.gz) = 7399e9a6708c32d678a72a63219e96f23be0be2336e50fd1348498d07041df90
-SIZE (rsync-3.3.0.tar.gz) = 1153969
-SHA256 (rsync-patches-3.3.0.tar.gz) = 3dd51cd88d25133681106f68622ebedbf191ab25a21ea336ba409136591864b0
-SIZE (rsync-patches-3.3.0.tar.gz) = 98487
+TIMESTAMP = 1736887703
+SHA256 (rsync-3.4.0.tar.gz) = 8e942f95a44226a012fe822faffa6c7fc38c34047add3a0c941e9bc8b8b93aa4
+SIZE (rsync-3.4.0.tar.gz) = 1167983
+SHA256 (rsync-patches-3.4.0.tar.gz) = 51533dc5b9b4293d3499b673df185c93484f3e6fcf2de52f9bf1f07fa3d7cbc1
+SIZE (rsync-patches-3.4.0.tar.gz) = 103831

--- a/net/rsync/pkg-plist
+++ b/net/rsync/pkg-plist
@@ -1,8 +1,8 @@
 bin/rsync
 bin/rsync-ssl
 sbin/rrsync
-share/man/man1/rrsync.1.gz
 share/man/man1/rsync.1.gz
 share/man/man1/rsync-ssl.1.gz
 share/man/man5/rsyncd.conf.5.gz
+%%PORTDOCS%%%%DOCSDIR%%/rrsync.1.md
 @sample %%ETCDIR%%/rsyncd.conf.sample


### PR DESCRIPTION
Full changelog: https://download.samba.org/pub/rsync/NEWS#3.4.0

Security:	CVE-2024-12084 - Heap Buffer Overflow in Checksum Parsing
Security:	CVE-2024-12085 - Info Leak via uninitialized Stack contents defeats ASLR
Security:	CVE-2024-12086 - Server leaks arbitrary client files
Security:	CVE-2024-12087 - Server can make client write files outside of destination directory using symbolic links
Security:	CVE-2024-12088 - --safe-links Bypass
Security:	CVE-2024-12747 -⁠ symlink race condition

PR:		284064
Reported by:	osa

(cherry picked from commit 6afdd4c669193f2041216071d5723e474ae041bf)

## Summary by Sourcery

Update rsync to version 3.4.0.

Bug Fixes:
- Fix heap buffer overflow in checksum parsing (CVE-2024-12084).
- Fix info leak via uninitialized stack contents (CVE-2024-12085).
- Fix server leak of arbitrary client files (CVE-2024-12086).
- Prevent server from making client write files outside the destination directory using symbolic links (CVE-2024-12087).
- Fix --safe-links bypass (CVE-2024-12088).
- Fix symlink race condition (CVE-2024-12747).