### PR TITLE
Add zsh settings port and update gershwin settings

### DIFF
--- a/shells/Makefile
+++ b/shells/Makefile
@@ -22,6 +22,7 @@
     SUBDIR += etsh
     SUBDIR += fd
     SUBDIR += fish
+    SUBDIR += ghostbsd-zsh-settings
     SUBDIR += git-prompt.zsh
     SUBDIR += heirloom-sh
     SUBDIR += ibsh

--- a/shells/ghostbsd-zsh-settings/Makefile
+++ b/shells/ghostbsd-zsh-settings/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	ghostbsd-zsh-settings
 PORTVERSION=	0.1
-CATEGORIES=	x11
+CATEGORIES=	shells
 
 MAINTAINER=	jpm820@proton.me
 COMMENT=	GhostBSD integration settings for the zsh shell

--- a/shells/ghostbsd-zsh-settings/Makefile
+++ b/shells/ghostbsd-zsh-settings/Makefile
@@ -1,0 +1,26 @@
+PORTNAME=	ghostbsd-zsh-settings
+PORTVERSION=	0.1
+CATEGORIES=	x11
+
+MAINTAINER=	jpm820@proton.me
+COMMENT=	GhostBSD integration settings for the zsh shell
+
+LICENSE=	BSD3CLAUSE
+
+RUN_DEPENDS=    zsh:shells/zsh \
+		${LOCALBASE}/share/zsh-autosuggestions/zsh-autosuggestions.zsh:shells/zsh-autosuggestions \
+		${LOCALBASE}/share/zsh/site-functions/_pkg:shells/zsh-completions
+
+USES=		uidfix
+
+USE_GITHUB=	yes
+GH_ACCOUNT=	ghostbsd
+
+NO_ARCH=	yes
+NO_BUILD=	yes
+
+do-install:
+	@${MKDIR} ${STAGEDIR}${PREFIX}/etc
+	${INSTALL_DATA} ${WRKSRC}/zshrc ${STAGEDIR}${PREFIX}/etc/zshrc
+
+.include <bsd.port.mk>

--- a/shells/ghostbsd-zsh-settings/distinfo
+++ b/shells/ghostbsd-zsh-settings/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1751384476
+SHA256 (ghostbsd-ghostbsd-zsh-settings-0.1_GH0.tar.gz) = 9553ac10bf00ba70108e250502f451e7d402ebf9ded19426be452243e99c1883
+SIZE (ghostbsd-ghostbsd-zsh-settings-0.1_GH0.tar.gz) = 2640

--- a/shells/ghostbsd-zsh-settings/pkg-descr
+++ b/shells/ghostbsd-zsh-settings/pkg-descr
@@ -1,0 +1,2 @@
+These are GhostBSD settings for zsh in installed mode
+that will enable fish like shell behavior for zsh.

--- a/shells/ghostbsd-zsh-settings/pkg-plist
+++ b/shells/ghostbsd-zsh-settings/pkg-plist
@@ -1,0 +1,1 @@
+etc/zshrc

--- a/x11/ghostbsd-gershwin-settings/Makefile
+++ b/x11/ghostbsd-gershwin-settings/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	ghostbsd-gershwin-settings
-DISTVERSION=	20250628
+DISTVERSION=	20250701
 CATEGORIES=	x11
 
 MAINTAINER=	jpm820@proton.me
@@ -12,7 +12,7 @@ USES=		uidfix
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	gershwin-desktop
-GH_TAGNAME=	8d285f0
+GH_TAGNAME=	340958d
 
 NO_ARCH=	yes
 NO_BUILD=	yes

--- a/x11/ghostbsd-gershwin-settings/distinfo
+++ b/x11/ghostbsd-gershwin-settings/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1751139400
-SHA256 (gershwin-desktop-ghostbsd-gershwin-settings-20250628-8d285f0_GH0.tar.gz) = 765a7f2938c01946d20901e0fb0e691e8d258d7693073431450020fa0faa95c1
-SIZE (gershwin-desktop-ghostbsd-gershwin-settings-20250628-8d285f0_GH0.tar.gz) = 1097
+TIMESTAMP = 1751381799
+SHA256 (gershwin-desktop-ghostbsd-gershwin-settings-20250701-340958d_GH0.tar.gz) = 938400cd58768425e87c10b74eb98e3dab5aa0d57f13f2e940e2f47b2c5073c9
+SIZE (gershwin-desktop-ghostbsd-gershwin-settings-20250701-340958d_GH0.tar.gz) = 1096


### PR DESCRIPTION
* Adds ghostbsd-zsh-settings port to make fish like settings for zsh
* Updates ghostbsd-gershwin-settings port to use xfwm4 instead of marco

## Summary by Sourcery

Add a new ghostbsd-zsh-settings port and update the ghostbsd-gershwin-settings port version

New Features:
- Add ghostbsd-zsh-settings port to provide GhostBSD-specific configurations for zsh

Enhancements:
- Bump ghostbsd-gershwin-settings port to version 20250701
- Include ghostbsd-zsh-settings in the shells ports Makefile