### PR TITLE
Fixes to appmenu ports

### DIFF
--- a/x11/gershwin-appmenu-registrar/Makefile
+++ b/x11/gershwin-appmenu-registrar/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=       appmenu-registrar
-DISTVERSION=    20250708
+DISTVERSION=    20250711
 CATEGORIES=     x11
 PKGNAMEPREFIX=	gershwin-
 
@@ -9,6 +9,8 @@ WWW=            https://gitlab.com/vala-panel-project/vala-panel-appmenu/-/tree/
 
 LICENSE=        LGPL3
 LICENSE_FILE=   ${WRKSRC}/LICENSE
+
+LIB_DEPENDS=    libbamf3.so:sysutils/bamf
 
 USES=   meson gnome pkgconfig gettext vala:build
 CONFLICTS=	appmenu-registrar

--- a/x11/gershwin-appmenu-registrar/distinfo
+++ b/x11/gershwin-appmenu-registrar/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1751997000
-SHA256 (gershwin-desktop-vala-panel-appmenu-20250708-4c00900_GH0.tar.gz) = 44caccdce76acb846f0b95529eb895dded771a326b4620e6aa772b429b2043de
-SIZE (gershwin-desktop-vala-panel-appmenu-20250708-4c00900_GH0.tar.gz) = 147433
+TIMESTAMP = 1752294825
+SHA256 (gershwin-desktop-vala-panel-appmenu-20250711-4c00900_GH0.tar.gz) = 44caccdce76acb846f0b95529eb895dded771a326b4620e6aa772b429b2043de
+SIZE (gershwin-desktop-vala-panel-appmenu-20250711-4c00900_GH0.tar.gz) = 147433

--- a/x11/gershwin-gtk-app-menu/Makefile
+++ b/x11/gershwin-gtk-app-menu/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=       appmenu-gtk-module
-DISTVERSION=    20250708
+DISTVERSION=    20250711
 CATEGORIES=     x11
 PKGNAMEPREFIX=	gershwin-
 
@@ -9,6 +9,8 @@ WWW=            https://gitlab.com/vala-panel-project/vala-panel-appmenu/-/tree/
 
 LICENSE=        LGPL3
 LICENSE_FILE=   ${WRKSRC}/subprojects/appmenu-gtk-module/LICENSE
+
+LIB_DEPENDS=    libbamf3.so:sysutils/bamf
 
 USES=		meson gnome pkgconfig vala:build
 CONFLICTS=	gtk-app-menu
@@ -29,6 +31,7 @@ GH_TAGNAME=     4c00900
 post-extract:
 	@${CP} ${FILESDIR}/meson.build ${WRKSRC}/meson.build
 	@${CP} ${FILESDIR}/gtk-meson.build ${WRKSRC}/subprojects/appmenu-gtk-module/meson.build
+	@${CP} ${FILESDIR}/translator-meson.build ${WRKSRC}/subprojects/appmenu-glib-translator/meson.build
 
 USE_GNOME=      gtk30 glib20 gtk20 gdkpixbuf
 GLIB_SCHEMAS=   org.appmenu.gtk-module.gschema.xml

--- a/x11/gershwin-gtk-app-menu/distinfo
+++ b/x11/gershwin-gtk-app-menu/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1751997050
-SHA256 (gershwin-desktop-vala-panel-appmenu-20250708-4c00900_GH0.tar.gz) = 44caccdce76acb846f0b95529eb895dded771a326b4620e6aa772b429b2043de
-SIZE (gershwin-desktop-vala-panel-appmenu-20250708-4c00900_GH0.tar.gz) = 147433
+TIMESTAMP = 1752294856
+SHA256 (gershwin-desktop-vala-panel-appmenu-20250711-4c00900_GH0.tar.gz) = 44caccdce76acb846f0b95529eb895dded771a326b4620e6aa772b429b2043de
+SIZE (gershwin-desktop-vala-panel-appmenu-20250711-4c00900_GH0.tar.gz) = 147433

--- a/x11/gershwin-gtk-app-menu/files/translator-meson.build
+++ b/x11/gershwin-gtk-app-menu/files/translator-meson.build
@@ -1,0 +1,92 @@
+project(
+  'appmenu-glib-translator',
+  'c',
+version : '25.04',
+meson_version : '>=0.61.0',
+license : 'LGPL-3.0-or-later',
+default_options : ['c_std=gnu11', 'buildtype=debugoptimized', 'warning_level=1']
+)
+
+add_project_arguments('-Dulong=unsigned long', language: 'c')	
+
+gnome = import('gnome')
+pkgconfig = import('pkgconfig')
+
+glib_ver = '>=2.52.0'
+giounix = dependency('gio-unix-2.0', version: glib_ver)
+gdkpixbuf = dependency('gdk-pixbuf-2.0', required: false)
+
+imp_sources = files(
+    'definitions.h',
+    'debug.c',
+    'debug.h',
+    'item.c',
+    'item.h',
+    'importer.c',
+    'importer.h',
+    'model.h',
+    'model.c',
+    'section.c',
+    'section.h',
+    'utils.c',
+    'utils.h'
+    )
+imp_headers = files('definitions.h')
+enum = 'importer-enums'
+importer_enums_gen = gnome.mkenums(
+  enum,
+  sources: imp_headers,
+  c_template: enum + '.c.template',
+  h_template: enum + '.h.template',
+)
+imp_dbus = gnome.gdbus_codegen(
+    'dbusmenu-interface',
+    sources: 'com.canonical.dbusmenu.xml',
+    interface_prefix: 'com.canonical',
+    autocleanup: 'all',
+    namespace: 'DBusMenu'
+)
+
+importer_name = 'appmenu-glib-translator'
+
+importer_lib = library(importer_name, imp_sources, importer_enums_gen, imp_dbus,
+    dependencies: [giounix, gdkpixbuf],
+    version: meson.project_version(),
+    install: true,
+    soversion: 0,
+    pic : true
+)
+importer_inc = include_directories('.')
+imp_public = ['importer.h']
+install_headers(imp_public, subdir : importer_name)
+
+pkgconfig.generate(importer_lib,
+             name: importer_name,
+             description: 'A translator from DBusMenu to GMenuModel',
+             requires: [giounix],
+             requires_private: [gdkpixbuf],
+             extra_cflags: ['-I${includedir}/'+importer_name]
+            )
+
+importer_gir = gnome.generate_gir(importer_lib,
+                    sources: imp_public,
+                    includes: ['GObject-2.0', 'Gio-2.0'],
+                    header: imp_public,
+                    namespace: 'AppmenuGLibTranslator',
+                    identifier_prefix: 'DBusMenu',
+                    symbol_prefix: 'dbus_menu',
+                    nsversion: meson.project_version(),
+                    install: true
+)
+
+importer_vapi = gnome.generate_vapi(importer_name,
+    sources: importer_gir[0],
+    packages: 'gio-2.0',
+    install: true,
+)
+
+importer_dep = declare_dependency(
+        include_directories: importer_inc,
+        dependencies: [importer_vapi, giounix, gdkpixbuf],
+        link_with: importer_lib
+)

--- a/x11/gershwin-xfce4-appmenu-plugin/Makefile
+++ b/x11/gershwin-xfce4-appmenu-plugin/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=       xfce4-appmenu-plugin
-DISTVERSION=    20250708
+DISTVERSION=    20250711
 CATEGORIES=     x11
 PKGNAMEPREFIX=	gershwin-
 
@@ -10,6 +10,7 @@ WWW=            https://gitlab.com/vala-panel-project/vala-panel-appmenu
 LICENSE=        LGPL3
 LICENSE_FILE=   ${WRKSRC}/LICENSE
 
+LIB_DEPENDS=    libbamf3.so:sysutils/bamf
 RUN_DEPENDS=    gershwin-appmenu-registrar>=0:x11/gershwin-appmenu-registrar \
 		gershwin-appmenu-gtk-module>=0:x11/gershwin-gtk-app-menu
 
@@ -35,5 +36,6 @@ GH_TAGNAME=     4c00900
 post-extract:
 	@${CP} ${FILESDIR}/meson.build ${WRKSRC}/meson.build
 	@${CP} ${FILESDIR}/lib-meson.build ${WRKSRC}/lib/meson.build
+	@${CP} ${FILESDIR}/translator-meson.build ${WRKSRC}/subprojects/appmenu-glib-translator/meson.build
 
 .include <bsd.port.mk>

--- a/x11/gershwin-xfce4-appmenu-plugin/distinfo
+++ b/x11/gershwin-xfce4-appmenu-plugin/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1751997085
-SHA256 (gershwin-desktop-vala-panel-appmenu-20250708-4c00900_GH0.tar.gz) = 44caccdce76acb846f0b95529eb895dded771a326b4620e6aa772b429b2043de
-SIZE (gershwin-desktop-vala-panel-appmenu-20250708-4c00900_GH0.tar.gz) = 147433
+TIMESTAMP = 1752294890
+SHA256 (gershwin-desktop-vala-panel-appmenu-20250711-4c00900_GH0.tar.gz) = 44caccdce76acb846f0b95529eb895dded771a326b4620e6aa772b429b2043de
+SIZE (gershwin-desktop-vala-panel-appmenu-20250711-4c00900_GH0.tar.gz) = 147433

--- a/x11/gershwin-xfce4-appmenu-plugin/files/translator-meson.build
+++ b/x11/gershwin-xfce4-appmenu-plugin/files/translator-meson.build
@@ -1,0 +1,92 @@
+project(
+  'appmenu-glib-translator',
+  'c',
+version : '25.04',
+meson_version : '>=0.61.0',
+license : 'LGPL-3.0-or-later',
+default_options : ['c_std=gnu11', 'buildtype=debugoptimized', 'warning_level=1']
+)
+
+add_project_arguments('-Dulong=unsigned long', language: 'c')	
+
+gnome = import('gnome')
+pkgconfig = import('pkgconfig')
+
+glib_ver = '>=2.52.0'
+giounix = dependency('gio-unix-2.0', version: glib_ver)
+gdkpixbuf = dependency('gdk-pixbuf-2.0', required: false)
+
+imp_sources = files(
+    'definitions.h',
+    'debug.c',
+    'debug.h',
+    'item.c',
+    'item.h',
+    'importer.c',
+    'importer.h',
+    'model.h',
+    'model.c',
+    'section.c',
+    'section.h',
+    'utils.c',
+    'utils.h'
+    )
+imp_headers = files('definitions.h')
+enum = 'importer-enums'
+importer_enums_gen = gnome.mkenums(
+  enum,
+  sources: imp_headers,
+  c_template: enum + '.c.template',
+  h_template: enum + '.h.template',
+)
+imp_dbus = gnome.gdbus_codegen(
+    'dbusmenu-interface',
+    sources: 'com.canonical.dbusmenu.xml',
+    interface_prefix: 'com.canonical',
+    autocleanup: 'all',
+    namespace: 'DBusMenu'
+)
+
+importer_name = 'appmenu-glib-translator'
+
+importer_lib = library(importer_name, imp_sources, importer_enums_gen, imp_dbus,
+    dependencies: [giounix, gdkpixbuf],
+    version: meson.project_version(),
+    install: true,
+    soversion: 0,
+    pic : true
+)
+importer_inc = include_directories('.')
+imp_public = ['importer.h']
+install_headers(imp_public, subdir : importer_name)
+
+pkgconfig.generate(importer_lib,
+             name: importer_name,
+             description: 'A translator from DBusMenu to GMenuModel',
+             requires: [giounix],
+             requires_private: [gdkpixbuf],
+             extra_cflags: ['-I${includedir}/'+importer_name]
+            )
+
+importer_gir = gnome.generate_gir(importer_lib,
+                    sources: imp_public,
+                    includes: ['GObject-2.0', 'Gio-2.0'],
+                    header: imp_public,
+                    namespace: 'AppmenuGLibTranslator',
+                    identifier_prefix: 'DBusMenu',
+                    symbol_prefix: 'dbus_menu',
+                    nsversion: meson.project_version(),
+                    install: true
+)
+
+importer_vapi = gnome.generate_vapi(importer_name,
+    sources: importer_gir[0],
+    packages: 'gio-2.0',
+    install: true,
+)
+
+importer_dep = declare_dependency(
+        include_directories: importer_inc,
+        dependencies: [importer_vapi, giounix, gdkpixbuf],
+        link_with: importer_lib
+)


### PR DESCRIPTION
I confirmed that these are fixed now with poudriere.

## Summary by Sourcery

Update gershwin appmenu ports to the latest release and fix build issues by adding a new dependency and meson build patches

Build:
- Bump DISTVERSION to 20250711 across gershwin-gtk-app-menu, gershwin-appmenu-registrar, and xfce4-appmenu-plugin ports
- Add libbamf3.so:sysutils/bamf as a runtime dependency in all three ports
- Include translator-meson.build patch in post-extract steps for gtk-app-menu and xfce4-appmenu-plugin to fix the meson build