### PR TITLE
Add ghostbsd-devel-tools meta port

### DIFF
--- a/devel/Makefile
+++ b/devel/Makefile
@@ -835,6 +835,7 @@
     SUBDIR += gh
     SUBDIR += ghidra
     SUBDIR += ghostie
+    SUBDIR += ghostbsd-devel-tools
     SUBDIR += ghq
     SUBDIR += ghub
     SUBDIR += ghub-devel

--- a/devel/ghostbsd-devel-tools/Makefile
+++ b/devel/ghostbsd-devel-tools/Makefile
@@ -19,7 +19,8 @@ RUN_DEPENDS=	git>0:devel/git \
 		py311-setuptools>0:devel/py-setuptools \
 		poudriere>0:ports-mgmt/poudriere \
 		python-distutils-extra>0:devel/py-python-distutils-extra \
-		pylint>0:devel/pylint
+		pylint>0:devel/pylint \
+		transmission-utils>0:net-p2p/transmission-utils
 
 USES=		metaport
 

--- a/devel/ghostbsd-devel-tools/Makefile
+++ b/devel/ghostbsd-devel-tools/Makefile
@@ -1,0 +1,34 @@
+PORTNAME=	ghostbsd-devel-tools
+PORTVERSION=	20250118
+CATEGORIES=	devel
+MASTER_SITES=	# empty
+DISTFILES=	# empty
+
+MAINTAINER=	ports@FreeBSD.org
+COMMENT=	GhostBSD development tools meta port
+WWW=		https://github.com/ghostbsd/ghostbsd-ports
+
+LICENSE=	BSD3CLAUSE
+
+RUN_DEPENDS=	git>0:devel/git \
+		nano>0:editors/nano \
+		vim>0:editors/vim \
+		gpg>0:security/gnupg \
+		shellcheck>0:devel/hs-ShellCheck \
+		portlint>0:ports-mgmt/portlint \
+		py311-setuptools>0:devel/py-setuptools \
+		poudriere>0:ports-mgmt/poudriere \
+		python-distutils-extra>0:devel/py-python-distutils-extra \
+		pylint>0:devel/pylint
+
+USES=		metaport
+
+NO_ARCH=	yes
+NO_BUILD=	yes
+
+do-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/share/doc/${PORTNAME}
+	${ECHO_CMD} "This is a meta port for GhostBSD development tools." > \
+		${STAGEDIR}${PREFIX}/share/doc/${PORTNAME}/README
+
+.include <bsd.port.mk>

--- a/devel/ghostbsd-devel-tools/pkg-descr
+++ b/devel/ghostbsd-devel-tools/pkg-descr
@@ -1,0 +1,20 @@
+GhostBSD development tools is a meta port that bundles all the essential
+tools needed for developing GhostBSD. This package provides a convenient
+one-stop installation for setting up a complete development environment.
+
+The included tools are:
+- git: Version control system for tracking changes and collaborating
+- nano: Simple command-line text editor
+- vim: Advanced text editor with extensive features
+- gpg: GNU Privacy Guard for signing commits and encrypting files
+- shellcheck: Shell script analysis and linting tool
+- portlint: FreeBSD ports Makefile quality checker
+- setuptools: Python package development utilities
+- poudriere: FreeBSD package building and testing framework
+- python-distutils-extra: Additional Python packaging utilities
+- pylint: Python source code analyzer for finding bugs and style issues
+
+This meta port simplifies the setup process for new GhostBSD developers
+by installing all necessary development utilities with a single command.
+
+WWW: https://github.com/ghostbsd/ghostbsd-ports

--- a/devel/ghostbsd-devel-tools/pkg-descr
+++ b/devel/ghostbsd-devel-tools/pkg-descr
@@ -13,6 +13,7 @@ The included tools are:
 - poudriere: FreeBSD package building and testing framework
 - python-distutils-extra: Additional Python packaging utilities
 - pylint: Python source code analyzer for finding bugs and style issues
+- transmission-utils: Command-line utilities for BitTorrent protocol
 
 This meta port simplifies the setup process for new GhostBSD developers
 by installing all necessary development utilities with a single command.


### PR DESCRIPTION
- Added `ghostbsd-devel-tools` to `devel/Makefile`.
- Introduced a new meta port `ghostbsd-devel-tools` for bundling essential GhostBSD development utilities.
- Included dependencies such as git, nano, vim, gpg, shellcheck, portlint, poudriere, and Python-related tools.
- Added a `README` documentation file to describe the purpose and usage of the meta-port.
- Provided a detailed package description in `pkg-descr`.

This simplifies the setup process for GhostBSD developers by offering a single point of installation for development tools.

## Summary by Sourcery

Add a new GhostBSD development tools meta port with required dependencies and accompanying documentation to streamline setup for developers.

New Features:
- Introduce ghostbsd-devel-tools meta port aggregating essential GhostBSD development utilities

Enhancements:
- Register ghostbsd-devel-tools in devel/Makefile to simplify port management

Documentation:
- Add README and detailed package description for the new meta port