### PR TITLE
x11/ghostbsd-xfce-settings: update to 25.02.0 and add ghostbsd-xfce as dependency

### DIFF
--- a/x11/ghostbsd-xfce-settings/Makefile
+++ b/x11/ghostbsd-xfce-settings/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	ghostbsd-xfce-settings
-PORTVERSION=	25.01.3
+PORTVERSION=	25.02.0
 CATEGORIES=	x11
 
 MAINTAINER=	ericturgeon@ghostbsd.org
@@ -7,7 +7,8 @@ COMMENT=	GhostBSD xfce settings in installed mode
 
 LICENSE=	BSD
 
-RUN_DEPENDS=	ghostbsd-wallpapers25>0:x11-themes/ghostbsd-wallpapers25
+RUN_DEPENDS=	ghostbsd-wallpapers25>0:x11-themes/ghostbsd-wallpapers25 \
+		ghostbsd-xfce>0:x11/ghostbsd-xfce
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	GhostBSD


### PR DESCRIPTION
This should fix setting not properly overriding xfce setting.

## Summary by Sourcery

Bump ghostbsd-xfce-settings port to 25.02.0 and add ghostbsd-xfce as a dependency to ensure Xfce settings override correctly

Bug Fixes:
- ensure Xfce settings properly override defaults by adding ghostbsd-xfce as a runtime dependency

Build:
- update PORTVERSION to 25.02.0 and add ghostbsd-xfce to RUN_DEPENDS